### PR TITLE
Check for GELF maximum chunk count

### DIFF
--- a/src/Gelf.Tests/GelfPublisherTest.cs
+++ b/src/Gelf.Tests/GelfPublisherTest.cs
@@ -63,5 +63,20 @@ namespace Gelf.Tests
             Assert.That(receivedObject.full_message.ToString(), Is.EqualTo(gelfMessageToSend.FullMessage));
             Assert.That(receivedObject.short_message.ToString(), Is.EqualTo(gelfMessageToSend.ShortMessage));
         }
+
+        [Test]
+        public void Given_large_payload_that_exced_gelf_max_chunk_count_publish_should_throw_message_to_big_exception()
+        {
+            var bigPayload = new byte[130000];
+
+            var gelfMessageToSend = new GelfMessage();
+
+            var random = new Random();
+            random.NextBytes(bigPayload);
+
+            gelfMessageToSend["big_payload"] = bigPayload;
+
+            Assert.Throws<GelfMessageTooBigException>(() => gelfPublisher.Publish(gelfMessageToSend));
+        }
     }
 }

--- a/src/Gelf/Constants.cs
+++ b/src/Gelf/Constants.cs
@@ -7,5 +7,6 @@ namespace Gelf
         public static readonly Encoding Encoding = Encoding.UTF8;
         public const int MaxHeaderSize = 8;
         public const int MaxChunkSize = 1024;
+        public const int MaxChunkCount = 128;
     }
 }

--- a/src/Gelf/Gelf.csproj
+++ b/src/Gelf/Gelf.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="GelfMessage.cs" />
+    <Compile Include="GelfMessageTooBigException.cs" />
     <Compile Include="GelfPublisher.cs" />
     <Compile Include="IGelfPublisher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
GELF UDP have a maximum chunk size count, that is not respected. Some GELF endpoints will complain about spec violation, this will add exception that gets thrown to alert developer that message is too big to send

http://docs.graylog.org/en/2.3/pages/gelf.html